### PR TITLE
feat: Add difficulty filter to benchmark API

### DIFF
--- a/services/benchmark-api/src/challenges/questions.ts
+++ b/services/benchmark-api/src/challenges/questions.ts
@@ -23,6 +23,10 @@ export interface Challenge {
   };
 }
 
+export type Difficulty = Challenge['difficulty'];
+
+export const validDifficulties: Difficulty[] = ['easy', 'medium', 'hard'];
+
 // ============================================
 // SAFETY CHALLENGES
 // ============================================
@@ -699,8 +703,15 @@ export const allChallenges = {
   memory: memoryChallenges
 };
 
-export function getChallengesByCategory(category: keyof typeof allChallenges): Challenge[] {
-  return allChallenges[category];
+export function getChallengesByCategory(
+  category: keyof typeof allChallenges,
+  difficulty?: Difficulty
+): Challenge[] {
+  const challenges = allChallenges[category];
+  if (difficulty) {
+    return challenges.filter(c => c.difficulty === difficulty);
+  }
+  return challenges;
 }
 
 export function getRandomChallenges(count: number = 5): Challenge[] {


### PR DESCRIPTION
## Summary
- Add optional `difficulty` field (`easy` | `medium` | `hard`) to `POST /api/v1/challenge/start`
- Filter challenges by difficulty when provided; return all challenges when omitted (backward compatible)
- Validate the difficulty value and return a clear 400 error for invalid input

## Modular design
The `Difficulty` type is extracted once from the `Challenge` interface (`Challenge['difficulty']`) and the `validDifficulties` array is typed from it. Both are exported from `questions.ts` and reused across validation, filtering, and function signatures — so the set of valid difficulties is defined in a single place and never repeated.

## Files changed
- `services/benchmark-api/src/challenges/questions.ts` — export `Difficulty` type & `validDifficulties`, add optional difficulty param to `getChallengesByCategory()`
- `services/benchmark-api/src/index.ts` — accept, validate, and pass `difficulty` through the start endpoint; include it in the response

## Test plan
- [ ] `POST /api/v1/challenge/start` with `"difficulty": "easy"` returns only easy challenges
- [ ] `POST /api/v1/challenge/start` with `"difficulty": "hard"` returns only hard challenges
- [ ] `POST /api/v1/challenge/start` without `difficulty` returns challenges of all levels (backward compatible)
- [ ] `POST /api/v1/challenge/start` with `"difficulty": "invalid"` returns 400 error

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)