### PR TITLE
feat: add AI Card adapter for cross-protocol identity

### DIFF
--- a/src/agentmesh/integrations/__init__.py
+++ b/src/agentmesh/integrations/__init__.py
@@ -2,11 +2,12 @@
 AgentMesh Integrations
 ======================
 
-Protocol and framework integrations for A2A, MCP, LangGraph, Swarm,
-Langflow, Flowise, and Haystack.
+Protocol and framework integrations for AI Card, A2A, MCP, LangGraph,
+Swarm, Langflow, Flowise, and Haystack.
 """
 
 from .a2a import A2AAgentCard, A2ATrustProvider
+from .ai_card import AICard, AICardIdentity, AICardService, AICardDiscovery
 from .mcp import TrustGatedMCPServer, TrustGatedMCPClient
 from .langgraph import TrustedGraphNode, TrustCheckpoint
 from .swarm import TrustedSwarm, TrustPolicy, TrustedAgent, HandoffVerifier
@@ -16,6 +17,11 @@ from .haystack import TrustedPipeline, TrustGateComponent, TrustAgentComponent
 from .http_middleware import TrustMiddleware, TrustConfig
 
 __all__ = [
+    # AI Card (cross-protocol identity standard)
+    "AICard",
+    "AICardIdentity",
+    "AICardService",
+    "AICardDiscovery",
     # A2A
     "A2AAgentCard",
     "A2ATrustProvider",

--- a/src/agentmesh/integrations/ai_card/__init__.py
+++ b/src/agentmesh/integrations/ai_card/__init__.py
@@ -1,0 +1,49 @@
+"""
+AI Card Integration for AgentMesh
+=================================
+
+Implements the AI Card standard (https://github.com/agent-card/ai-card)
+for cross-protocol agent identity and discovery.
+
+AI Card provides a common format for:
+- Agent metadata (name, description, version)
+- Identity (DIDs, public keys)
+- Verifiable metadata (trust scores, capability proofs, delegation)
+- Protocol services (A2A skills, MCP tools, etc.)
+- Static discovery via /.well-known/ai-card.json
+
+This adapter bridges AgentMesh's CMVK identity primitives to the
+AI Card format, enabling cross-protocol trust verification.
+
+Example:
+    >>> from agentmesh.identity import AgentIdentity
+    >>> from agentmesh.integrations.ai_card import AICard
+    >>>
+    >>> identity = AgentIdentity.create(
+    ...     name="sql-agent",
+    ...     sponsor="human@example.com",
+    ...     capabilities=["execute:sql", "read:database"],
+    ... )
+    >>> card = AICard.from_identity(identity)
+    >>> card.to_json()  # Serve at /.well-known/ai-card.json
+"""
+
+from .schema import (
+    AICard,
+    AICardIdentity,
+    AICardService,
+    AICardVerifiable,
+    CapabilityAttestation,
+    DelegationRecord,
+)
+from .discovery import AICardDiscovery
+
+__all__ = [
+    "AICard",
+    "AICardIdentity",
+    "AICardService",
+    "AICardVerifiable",
+    "CapabilityAttestation",
+    "DelegationRecord",
+    "AICardDiscovery",
+]

--- a/src/agentmesh/integrations/ai_card/discovery.py
+++ b/src/agentmesh/integrations/ai_card/discovery.py
@@ -1,0 +1,138 @@
+"""
+AI Card Discovery
+
+Handles serving AI Cards at ``/.well-known/ai-card.json`` and
+managing a local catalog of cards for discovery.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from .schema import AICard
+
+logger = logging.getLogger(__name__)
+
+
+class AICardDiscovery:
+    """Manages AI Card discovery and catalog.
+
+    Provides:
+    - Local card catalog for registered agents
+    - JSON responses for ``/.well-known/ai-card.json``
+    - Card lookup by DID, name, or capability
+    - TTL-based verification caching
+
+    Example:
+        >>> discovery = AICardDiscovery()
+        >>> discovery.register(card)
+        >>> # Serve at /.well-known/ai-card.json
+        >>> json_response = discovery.get_card_json("did:mesh:abc123")
+    """
+
+    def __init__(self, cache_ttl_seconds: int = 900):
+        self._cards: Dict[str, AICard] = {}  # keyed by DID
+        self._verified_cache: Dict[str, tuple[bool, datetime]] = {}
+        self._cache_ttl = timedelta(seconds=cache_ttl_seconds)
+
+    def register(self, card: AICard, verify: bool = True) -> bool:
+        """Register an AI Card in the catalog.
+
+        Args:
+            card: The AI Card to register.
+            verify: Whether to verify the card signature before registering.
+
+        Returns:
+            True if registered successfully.
+        """
+        if not card.identity:
+            logger.warning("Cannot register card without identity")
+            return False
+
+        if verify and not card.verify_signature():
+            logger.warning(f"Card signature verification failed for {card.identity.did}")
+            return False
+
+        self._cards[card.identity.did] = card
+        self._verified_cache[card.identity.did] = (True, datetime.now(timezone.utc))
+        logger.info(f"Registered AI Card for {card.identity.did}")
+        return True
+
+    def get(self, did: str) -> Optional[AICard]:
+        """Get a card by agent DID."""
+        return self._cards.get(did)
+
+    def get_card_json(self, did: str) -> Optional[str]:
+        """Get AI Card JSON for serving at ``/.well-known/ai-card.json``.
+
+        Args:
+            did: Agent DID to look up.
+
+        Returns:
+            JSON string or None if not found.
+        """
+        card = self._cards.get(did)
+        return card.to_json() if card else None
+
+    def get_catalog_json(self, indent: int = 2) -> str:
+        """Get the full catalog as JSON.
+
+        Returns:
+            JSON string with all registered cards.
+        """
+        catalog = {
+            "cards": [
+                json.loads(card.to_json()) for card in self._cards.values()
+            ],
+            "total": len(self._cards),
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        return json.dumps(catalog, indent=indent)
+
+    def is_verified(self, did: str) -> bool:
+        """Check if a card is verified (with caching)."""
+        if did in self._verified_cache:
+            verified, timestamp = self._verified_cache[did]
+            if datetime.now(timezone.utc) - timestamp < self._cache_ttl:
+                return verified
+
+        card = self._cards.get(did)
+        if not card:
+            return False
+
+        verified = card.verify_signature()
+        self._verified_cache[did] = (verified, datetime.now(timezone.utc))
+        return verified
+
+    def find_by_capability(self, capability: str) -> List[AICard]:
+        """Find cards that have a specific capability attestation."""
+        return [
+            card for card in self._cards.values()
+            if capability in card.verifiable.capability_attestations
+        ]
+
+    def find_by_protocol(self, protocol: str) -> List[AICard]:
+        """Find cards that support a specific protocol."""
+        return [
+            card for card in self._cards.values()
+            if any(s.protocol == protocol for s in card.services)
+        ]
+
+    def list_cards(self) -> List[AICard]:
+        """List all registered cards."""
+        return list(self._cards.values())
+
+    def remove(self, did: str) -> bool:
+        """Remove a card from the catalog."""
+        if did in self._cards:
+            del self._cards[did]
+            self._verified_cache.pop(did, None)
+            return True
+        return False
+
+    def clear_cache(self) -> None:
+        """Clear the verification cache."""
+        self._verified_cache.clear()

--- a/src/agentmesh/integrations/ai_card/schema.py
+++ b/src/agentmesh/integrations/ai_card/schema.py
@@ -1,0 +1,422 @@
+"""
+AI Card Schema Models
+
+Data models aligned with the AI Card standard
+(https://github.com/agent-card/ai-card).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AICardIdentity(BaseModel):
+    """Identity metadata for an AI Card.
+
+    Maps to AI Card spec's identity section, supporting DIDs and
+    Ed25519 public keys from AgentMesh's CMVK infrastructure.
+    """
+
+    did: str = Field(..., description="Decentralized Identifier (e.g. did:mesh:abc123)")
+    public_key: str = Field(..., description="Ed25519 public key (base64)")
+    algorithm: str = Field(default="Ed25519", description="Signing algorithm")
+    key_id: Optional[str] = Field(None, description="Key identifier for rotation")
+
+
+class CapabilityAttestation(BaseModel):
+    """Cryptographic attestation that an agent has a capability."""
+
+    capability: str = Field(..., description="Capability being attested")
+    proof: str = Field(..., description="Base64-encoded cryptographic proof")
+    issuer_did: str = Field(..., description="DID of the attestation issuer")
+    issued_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: Optional[datetime] = None
+
+
+class DelegationRecord(BaseModel):
+    """Record of capability delegation between agents."""
+
+    delegator_did: str = Field(..., description="DID of the delegating agent")
+    delegatee_did: str = Field(..., description="DID of the receiving agent")
+    capabilities: List[str] = Field(default_factory=list)
+    signature: str = Field(..., description="Cryptographic signature over delegation")
+    issued_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: Optional[datetime] = None
+
+
+class AICardVerifiable(BaseModel):
+    """Verifiable metadata for an AI Card.
+
+    Includes trust scores, capability attestations, and delegation chains
+    that can be cryptographically verified.
+    """
+
+    trust_score: float = Field(default=1.0, ge=0.0, le=1.0)
+    capability_attestations: Dict[str, CapabilityAttestation] = Field(default_factory=dict)
+    delegation_chain: List[DelegationRecord] = Field(default_factory=list)
+
+
+class AICardService(BaseModel):
+    """Protocol-specific service entry in an AI Card.
+
+    Each service describes a protocol the agent supports (A2A, MCP, etc.)
+    along with its endpoint and protocol-specific metadata.
+    """
+
+    protocol: str = Field(..., description="Protocol identifier (e.g. 'a2a', 'mcp')")
+    url: str = Field(..., description="Service endpoint URL")
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Protocol-specific metadata (A2A skills, MCP tools, etc.)",
+    )
+
+
+class AICardSignature(BaseModel):
+    """Cryptographic signature over the AI Card content."""
+
+    algorithm: str = Field(default="Ed25519")
+    public_key: str = Field(..., description="Signer's public key (base64)")
+    signature: str = Field(..., description="Base64-encoded signature")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class AICard(BaseModel):
+    """AI Card — cross-protocol agent metadata standard.
+
+    Implements the AI Card spec for agent discovery, identity verification,
+    and trust establishment across protocols (A2A, MCP, etc.).
+
+    The card is the canonical identity document for an agent, served at
+    ``/.well-known/ai-card.json``.
+    """
+
+    # Common server metadata
+    name: str = Field(..., description="Agent name")
+    description: str = Field(default="", description="Agent description")
+    version: str = Field(default="1.0.0", description="Agent version")
+    homepage: Optional[str] = Field(None, description="Documentation URL")
+
+    # Identity
+    identity: Optional[AICardIdentity] = None
+
+    # Verifiable metadata
+    verifiable: AICardVerifiable = Field(default_factory=AICardVerifiable)
+
+    # Protocol services
+    services: List[AICardService] = Field(default_factory=list)
+
+    # Card signature
+    card_signature: Optional[AICardSignature] = None
+
+    # Timestamps
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: Optional[datetime] = None
+
+    # Custom extension data
+    custom: Dict[str, Any] = Field(default_factory=dict)
+
+    def _get_signable_content(self) -> str:
+        """Get deterministic content for signing."""
+        content = {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "created_at": self.created_at.isoformat(),
+        }
+        if self.identity:
+            content["identity"] = {
+                "did": self.identity.did,
+                "public_key": self.identity.public_key,
+            }
+        if self.expires_at:
+            content["expires_at"] = self.expires_at.isoformat()
+        content["capabilities"] = sorted(
+            a.capability for a in self.verifiable.capability_attestations.values()
+        )
+        return json.dumps(content, sort_keys=True, separators=(",", ":"))
+
+    def sign(self, identity: Any) -> None:
+        """Sign this AI Card with an AgentIdentity.
+
+        Args:
+            identity: An ``AgentIdentity`` instance with a private key.
+        """
+        from agentmesh.identity.agent_id import AgentIdentity
+
+        if not isinstance(identity, AgentIdentity):
+            raise TypeError(f"Expected AgentIdentity, got {type(identity).__name__}")
+
+        # Set identity fields from the signer
+        self.identity = AICardIdentity(
+            did=str(identity.did),
+            public_key=identity.public_key,
+            key_id=identity.verification_key_id,
+        )
+
+        signable = self._get_signable_content()
+        signature_b64 = identity.sign(signable.encode())
+
+        self.card_signature = AICardSignature(
+            public_key=identity.public_key,
+            signature=signature_b64,
+        )
+
+    def verify_signature(self) -> bool:
+        """Verify the card's signature is valid.
+
+        Returns:
+            True if the signature is valid and matches the identity.
+        """
+        if not self.identity or not self.card_signature:
+            return False
+
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        import base64
+
+        try:
+            public_key_bytes = base64.b64decode(self.identity.public_key)
+            public_key = ed25519.Ed25519PublicKey.from_public_bytes(public_key_bytes)
+            signature_bytes = base64.b64decode(self.card_signature.signature)
+            signable = self._get_signable_content()
+            public_key.verify(signature_bytes, signable.encode())
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def from_identity(
+        cls,
+        identity: Any,
+        description: str = "",
+        services: Optional[List[AICardService]] = None,
+    ) -> "AICard":
+        """Create a signed AI Card from an AgentIdentity.
+
+        Args:
+            identity: An ``AgentIdentity`` with a private key.
+            description: Agent description.
+            services: Protocol service entries.
+
+        Returns:
+            A signed ``AICard``.
+        """
+        # Build capability attestations from identity capabilities
+        attestations = {}
+        for cap in getattr(identity, "capabilities", []):
+            sig = identity.sign(f"capability:{cap}".encode())
+            attestations[cap] = CapabilityAttestation(
+                capability=cap,
+                proof=sig,
+                issuer_did=str(identity.did),
+            )
+
+        card = cls(
+            name=identity.name,
+            description=description or getattr(identity, "description", "") or "",
+            services=services or [],
+            verifiable=AICardVerifiable(
+                trust_score=1.0,
+                capability_attestations=attestations,
+            ),
+        )
+        card.sign(identity)
+        return card
+
+    @classmethod
+    def from_trusted_agent_card(cls, trusted_card: Any) -> "AICard":
+        """Convert a TrustedAgentCard to an AI Card.
+
+        Bridges the existing AgentMesh ``TrustedAgentCard`` format to
+        the cross-protocol AI Card standard.
+
+        Args:
+            trusted_card: A ``TrustedAgentCard`` instance.
+
+        Returns:
+            An ``AICard`` (unsigned — call ``sign()`` to add signature).
+        """
+        identity = None
+        if trusted_card.agent_did and trusted_card.public_key:
+            identity = AICardIdentity(
+                did=trusted_card.agent_did,
+                public_key=trusted_card.public_key,
+            )
+
+        return cls(
+            name=trusted_card.name,
+            description=trusted_card.description,
+            identity=identity,
+            verifiable=AICardVerifiable(
+                trust_score=trusted_card.trust_score,
+            ),
+            created_at=trusted_card.created_at,
+            custom=trusted_card.metadata,
+        )
+
+    def to_json(self, indent: int = 2) -> str:
+        """Serialize to AI Card JSON for ``/.well-known/ai-card.json``.
+
+        Returns:
+            JSON string conforming to the AI Card spec.
+        """
+        data: Dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "created_at": self.created_at.isoformat(),
+        }
+
+        if self.homepage:
+            data["homepage"] = self.homepage
+
+        if self.identity:
+            data["identity"] = {
+                "did": self.identity.did,
+                "public_key": self.identity.public_key,
+                "algorithm": self.identity.algorithm,
+            }
+            if self.identity.key_id:
+                data["identity"]["key_id"] = self.identity.key_id
+
+        # Verifiable metadata
+        verifiable: Dict[str, Any] = {
+            "trust_score": self.verifiable.trust_score,
+        }
+        if self.verifiable.capability_attestations:
+            verifiable["capability_attestations"] = {
+                k: {
+                    "capability": v.capability,
+                    "proof": v.proof,
+                    "issuer_did": v.issuer_did,
+                    "issued_at": v.issued_at.isoformat(),
+                    **({"expires_at": v.expires_at.isoformat()} if v.expires_at else {}),
+                }
+                for k, v in self.verifiable.capability_attestations.items()
+            }
+        if self.verifiable.delegation_chain:
+            verifiable["delegation_chain"] = [
+                {
+                    "delegator_did": d.delegator_did,
+                    "delegatee_did": d.delegatee_did,
+                    "capabilities": d.capabilities,
+                    "signature": d.signature,
+                    "issued_at": d.issued_at.isoformat(),
+                    **({"expires_at": d.expires_at.isoformat()} if d.expires_at else {}),
+                }
+                for d in self.verifiable.delegation_chain
+            ]
+        data["verifiable"] = verifiable
+
+        # Services
+        if self.services:
+            data["services"] = [
+                {
+                    "protocol": s.protocol,
+                    "url": s.url,
+                    **({"metadata": s.metadata} if s.metadata else {}),
+                }
+                for s in self.services
+            ]
+
+        if self.card_signature:
+            data["card_signature"] = {
+                "algorithm": self.card_signature.algorithm,
+                "public_key": self.card_signature.public_key,
+                "signature": self.card_signature.signature,
+                "timestamp": self.card_signature.timestamp.isoformat(),
+            }
+
+        if self.expires_at:
+            data["expires_at"] = self.expires_at.isoformat()
+
+        if self.custom:
+            data["custom"] = self.custom
+
+        return json.dumps(data, indent=indent)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "AICard":
+        """Deserialize an AI Card from JSON.
+
+        Args:
+            json_str: JSON string from ``/.well-known/ai-card.json``.
+
+        Returns:
+            Parsed ``AICard`` instance.
+        """
+        data = json.loads(json_str)
+
+        identity = None
+        if "identity" in data:
+            identity = AICardIdentity(
+                did=data["identity"]["did"],
+                public_key=data["identity"]["public_key"],
+                algorithm=data["identity"].get("algorithm", "Ed25519"),
+                key_id=data["identity"].get("key_id"),
+            )
+
+        verifiable = AICardVerifiable()
+        if "verifiable" in data:
+            v = data["verifiable"]
+            attestations = {}
+            for k, att in v.get("capability_attestations", {}).items():
+                attestations[k] = CapabilityAttestation(
+                    capability=att["capability"],
+                    proof=att["proof"],
+                    issuer_did=att["issuer_did"],
+                    issued_at=datetime.fromisoformat(att["issued_at"]),
+                    expires_at=datetime.fromisoformat(att["expires_at"]) if att.get("expires_at") else None,
+                )
+            delegation_chain = [
+                DelegationRecord(
+                    delegator_did=d["delegator_did"],
+                    delegatee_did=d["delegatee_did"],
+                    capabilities=d["capabilities"],
+                    signature=d["signature"],
+                    issued_at=datetime.fromisoformat(d["issued_at"]),
+                    expires_at=datetime.fromisoformat(d["expires_at"]) if d.get("expires_at") else None,
+                )
+                for d in v.get("delegation_chain", [])
+            ]
+            verifiable = AICardVerifiable(
+                trust_score=v.get("trust_score", 1.0),
+                capability_attestations=attestations,
+                delegation_chain=delegation_chain,
+            )
+
+        card_signature = None
+        if "card_signature" in data:
+            cs = data["card_signature"]
+            card_signature = AICardSignature(
+                algorithm=cs.get("algorithm", "Ed25519"),
+                public_key=cs["public_key"],
+                signature=cs["signature"],
+                timestamp=datetime.fromisoformat(cs["timestamp"]),
+            )
+
+        services = [
+            AICardService(
+                protocol=s["protocol"],
+                url=s["url"],
+                metadata=s.get("metadata", {}),
+            )
+            for s in data.get("services", [])
+        ]
+
+        return cls(
+            name=data["name"],
+            description=data.get("description", ""),
+            version=data.get("version", "1.0.0"),
+            homepage=data.get("homepage"),
+            identity=identity,
+            verifiable=verifiable,
+            services=services,
+            card_signature=card_signature,
+            created_at=datetime.fromisoformat(data["created_at"]) if "created_at" in data else datetime.now(timezone.utc),
+            expires_at=datetime.fromisoformat(data["expires_at"]) if data.get("expires_at") else None,
+            custom=data.get("custom", {}),
+        )

--- a/tests/test_ai_card.py
+++ b/tests/test_ai_card.py
@@ -1,0 +1,431 @@
+"""
+Tests for AI Card integration.
+
+Covers: schema models, identity mapping, card signing/verification,
+JSON serialization, discovery catalog, and TrustedAgentCard bridging.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agentmesh.identity.agent_id import AgentIdentity
+from agentmesh.integrations.ai_card.schema import (
+    AICard,
+    AICardIdentity,
+    AICardService,
+    AICardSignature,
+    AICardVerifiable,
+    CapabilityAttestation,
+    DelegationRecord,
+)
+from agentmesh.integrations.ai_card.discovery import AICardDiscovery
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def identity():
+    """Create a test AgentIdentity with private key."""
+    return AgentIdentity.create(
+        name="test-agent",
+        sponsor="sponsor@example.com",
+        capabilities=["read:data", "write:logs"],
+        description="A test agent",
+    )
+
+
+@pytest.fixture
+def identity_b():
+    """Create a second test AgentIdentity."""
+    return AgentIdentity.create(
+        name="peer-agent",
+        sponsor="peer@example.com",
+        capabilities=["execute:sql"],
+    )
+
+
+@pytest.fixture
+def signed_card(identity):
+    """Create a signed AI Card."""
+    return AICard.from_identity(identity, description="Test agent card")
+
+
+# ── Schema Tests ──────────────────────────────────────────────
+
+
+class TestAICardSchema:
+    """Test AI Card schema model creation."""
+
+    def test_create_minimal_card(self):
+        card = AICard(name="minimal-agent")
+        assert card.name == "minimal-agent"
+        assert card.description == ""
+        assert card.version == "1.0.0"
+        assert card.identity is None
+        assert card.services == []
+        assert card.card_signature is None
+
+    def test_create_full_card(self):
+        card = AICard(
+            name="full-agent",
+            description="Full agent",
+            version="2.0.0",
+            homepage="https://example.com",
+            identity=AICardIdentity(
+                did="did:mesh:abc123",
+                public_key="dGVzdA==",
+            ),
+            services=[
+                AICardService(protocol="a2a", url="https://agent.example.com/a2a"),
+                AICardService(protocol="mcp", url="https://agent.example.com/mcp", metadata={"tools": ["search"]}),
+            ],
+            custom={"org": "test-org"},
+        )
+        assert card.name == "full-agent"
+        assert card.identity.did == "did:mesh:abc123"
+        assert len(card.services) == 2
+        assert card.services[0].protocol == "a2a"
+        assert card.services[1].metadata["tools"] == ["search"]
+        assert card.custom["org"] == "test-org"
+
+    def test_identity_model(self):
+        ident = AICardIdentity(
+            did="did:mesh:abc",
+            public_key="key123",
+            algorithm="Ed25519",
+            key_id="key-001",
+        )
+        assert ident.did == "did:mesh:abc"
+        assert ident.algorithm == "Ed25519"
+        assert ident.key_id == "key-001"
+
+    def test_capability_attestation(self):
+        att = CapabilityAttestation(
+            capability="read:data",
+            proof="proof-bytes",
+            issuer_did="did:mesh:issuer",
+        )
+        assert att.capability == "read:data"
+        assert att.expires_at is None
+
+    def test_delegation_record(self):
+        rec = DelegationRecord(
+            delegator_did="did:mesh:root",
+            delegatee_did="did:mesh:agent",
+            capabilities=["read:data"],
+            signature="sig-bytes",
+        )
+        assert rec.delegator_did == "did:mesh:root"
+        assert rec.capabilities == ["read:data"]
+
+
+# ── Identity Mapping Tests ────────────────────────────────────
+
+
+class TestIdentityMapping:
+    """Test mapping AgentIdentity to AI Card format."""
+
+    def test_from_identity_sets_identity(self, identity):
+        card = AICard.from_identity(identity)
+        assert card.identity is not None
+        assert card.identity.did == str(identity.did)
+        assert card.identity.public_key == identity.public_key
+        assert card.identity.algorithm == "Ed25519"
+
+    def test_from_identity_preserves_name(self, identity):
+        card = AICard.from_identity(identity)
+        assert card.name == identity.name
+
+    def test_from_identity_preserves_capabilities(self, identity):
+        card = AICard.from_identity(identity)
+        assert "read:data" in card.verifiable.capability_attestations
+        assert "write:logs" in card.verifiable.capability_attestations
+
+    def test_from_identity_with_description(self, identity):
+        card = AICard.from_identity(identity, description="Custom desc")
+        assert card.description == "Custom desc"
+
+    def test_from_identity_with_services(self, identity):
+        services = [AICardService(protocol="a2a", url="https://example.com/a2a")]
+        card = AICard.from_identity(identity, services=services)
+        assert len(card.services) == 1
+        assert card.services[0].protocol == "a2a"
+
+    def test_key_id_from_identity(self, identity):
+        card = AICard.from_identity(identity)
+        assert card.identity.key_id == identity.verification_key_id
+
+
+# ── Card Signing Tests ────────────────────────────────────────
+
+
+class TestCardSigning:
+    """Test cryptographic card signing and verification."""
+
+    def test_sign_sets_signature(self, identity):
+        card = AICard(name="test")
+        card.sign(identity)
+        assert card.card_signature is not None
+        assert card.card_signature.signature != ""
+        assert card.card_signature.public_key == identity.public_key
+
+    def test_signed_card_verifies(self, signed_card):
+        assert signed_card.verify_signature() is True
+
+    def test_tampered_card_fails_verification(self, signed_card):
+        signed_card.name = "tampered-name"
+        assert signed_card.verify_signature() is False
+
+    def test_unsigned_card_fails_verification(self):
+        card = AICard(name="unsigned")
+        assert card.verify_signature() is False
+
+    def test_card_without_identity_fails_verification(self):
+        card = AICard(
+            name="no-identity",
+            card_signature=AICardSignature(
+                public_key="fake",
+                signature="fake",
+            ),
+        )
+        assert card.verify_signature() is False
+
+    def test_sign_rejects_non_identity(self):
+        card = AICard(name="test")
+        with pytest.raises(TypeError):
+            card.sign("not-an-identity")
+
+    def test_from_identity_produces_valid_signature(self, identity):
+        card = AICard.from_identity(identity)
+        assert card.verify_signature() is True
+
+
+# ── JSON Serialization Tests ──────────────────────────────────
+
+
+class TestJSONSerialization:
+    """Test AI Card JSON serialization and deserialization."""
+
+    def test_roundtrip_minimal(self):
+        card = AICard(name="roundtrip-agent")
+        json_str = card.to_json()
+        restored = AICard.from_json(json_str)
+        assert restored.name == "roundtrip-agent"
+
+    def test_roundtrip_signed_card(self, signed_card):
+        json_str = signed_card.to_json()
+        restored = AICard.from_json(json_str)
+        assert restored.name == signed_card.name
+        assert restored.identity.did == signed_card.identity.did
+        assert restored.identity.public_key == signed_card.identity.public_key
+        assert restored.card_signature.signature == signed_card.card_signature.signature
+
+    def test_roundtrip_with_services(self, identity):
+        services = [
+            AICardService(protocol="a2a", url="https://a2a.example.com", metadata={"skills": ["search"]}),
+            AICardService(protocol="mcp", url="https://mcp.example.com"),
+        ]
+        card = AICard.from_identity(identity, services=services)
+        json_str = card.to_json()
+        restored = AICard.from_json(json_str)
+        assert len(restored.services) == 2
+        assert restored.services[0].protocol == "a2a"
+        assert restored.services[0].metadata["skills"] == ["search"]
+
+    def test_roundtrip_with_delegation(self, identity, identity_b):
+        card = AICard.from_identity(identity)
+        delegation_data = f"{identity.did}:{identity_b.did}:read:data"
+        sig = identity.sign(delegation_data.encode())
+        card.verifiable.delegation_chain.append(
+            DelegationRecord(
+                delegator_did=str(identity.did),
+                delegatee_did=str(identity_b.did),
+                capabilities=["read:data"],
+                signature=sig,
+            )
+        )
+        json_str = card.to_json()
+        restored = AICard.from_json(json_str)
+        assert len(restored.verifiable.delegation_chain) == 1
+        assert restored.verifiable.delegation_chain[0].delegator_did == str(identity.did)
+
+    def test_roundtrip_with_custom(self, identity):
+        card = AICard.from_identity(identity)
+        card.custom = {"org": "acme", "tier": "enterprise"}
+        json_str = card.to_json()
+        restored = AICard.from_json(json_str)
+        assert restored.custom["org"] == "acme"
+
+    def test_to_json_is_valid_json(self, signed_card):
+        json_str = signed_card.to_json()
+        data = json.loads(json_str)
+        assert "name" in data
+        assert "identity" in data
+        assert "verifiable" in data
+        assert "card_signature" in data
+
+    def test_from_json_handles_missing_optional_fields(self):
+        minimal_json = json.dumps({"name": "minimal"})
+        card = AICard.from_json(minimal_json)
+        assert card.name == "minimal"
+        assert card.identity is None
+        assert card.services == []
+
+
+# ── TrustedAgentCard Bridge Tests ─────────────────────────────
+
+
+class TestTrustedAgentCardBridge:
+    """Test converting TrustedAgentCard to AI Card."""
+
+    def test_bridge_from_trusted_card(self, identity):
+        from agentmesh.trust.cards import TrustedAgentCard
+
+        trusted = TrustedAgentCard.from_identity(identity)
+        ai_card = AICard.from_trusted_agent_card(trusted)
+
+        assert ai_card.name == trusted.name
+        assert ai_card.description == trusted.description
+        assert ai_card.identity is not None
+        assert ai_card.identity.did == trusted.agent_did
+        assert ai_card.identity.public_key == trusted.public_key
+        assert ai_card.verifiable.trust_score == trusted.trust_score
+
+    def test_bridge_preserves_metadata(self, identity):
+        from agentmesh.trust.cards import TrustedAgentCard
+
+        trusted = TrustedAgentCard.from_identity(identity)
+        trusted.metadata = {"env": "production"}
+        ai_card = AICard.from_trusted_agent_card(trusted)
+        assert ai_card.custom["env"] == "production"
+
+    def test_bridge_without_identity(self):
+        from agentmesh.trust.cards import TrustedAgentCard
+
+        trusted = TrustedAgentCard(name="no-id", description="No identity")
+        ai_card = AICard.from_trusted_agent_card(trusted)
+        assert ai_card.name == "no-id"
+        assert ai_card.identity is None
+
+
+# ── Discovery Tests ───────────────────────────────────────────
+
+
+class TestAICardDiscovery:
+    """Test AI Card discovery catalog."""
+
+    def test_register_and_get(self, signed_card):
+        discovery = AICardDiscovery()
+        assert discovery.register(signed_card) is True
+        retrieved = discovery.get(signed_card.identity.did)
+        assert retrieved is not None
+        assert retrieved.name == signed_card.name
+
+    def test_register_rejects_invalid_signature(self):
+        card = AICard(
+            name="bad-sig",
+            identity=AICardIdentity(did="did:mesh:bad", public_key="fake"),
+            card_signature=AICardSignature(public_key="fake", signature="fake"),
+        )
+        discovery = AICardDiscovery()
+        assert discovery.register(card) is False
+
+    def test_register_rejects_no_identity(self):
+        card = AICard(name="no-identity")
+        discovery = AICardDiscovery()
+        assert discovery.register(card) is False
+
+    def test_register_without_verify(self):
+        card = AICard(
+            name="skip-verify",
+            identity=AICardIdentity(did="did:mesh:skip", public_key="fake"),
+        )
+        discovery = AICardDiscovery()
+        assert discovery.register(card, verify=False) is True
+
+    def test_get_card_json(self, signed_card):
+        discovery = AICardDiscovery()
+        discovery.register(signed_card)
+        json_str = discovery.get_card_json(signed_card.identity.did)
+        assert json_str is not None
+        data = json.loads(json_str)
+        assert data["name"] == signed_card.name
+
+    def test_get_card_json_not_found(self):
+        discovery = AICardDiscovery()
+        assert discovery.get_card_json("did:mesh:nonexistent") is None
+
+    def test_catalog_json(self, signed_card):
+        discovery = AICardDiscovery()
+        discovery.register(signed_card)
+        catalog = json.loads(discovery.get_catalog_json())
+        assert catalog["total"] == 1
+        assert len(catalog["cards"]) == 1
+        assert "generated_at" in catalog
+
+    def test_find_by_capability(self, identity, identity_b):
+        discovery = AICardDiscovery()
+        card_a = AICard.from_identity(identity)
+        card_b = AICard.from_identity(identity_b)
+        discovery.register(card_a)
+        discovery.register(card_b)
+
+        results = discovery.find_by_capability("read:data")
+        assert len(results) == 1
+        assert results[0].name == "test-agent"
+
+        results = discovery.find_by_capability("execute:sql")
+        assert len(results) == 1
+        assert results[0].name == "peer-agent"
+
+    def test_find_by_protocol(self, identity):
+        discovery = AICardDiscovery()
+        card = AICard.from_identity(
+            identity,
+            services=[AICardService(protocol="a2a", url="https://a2a.example.com")],
+        )
+        discovery.register(card)
+
+        results = discovery.find_by_protocol("a2a")
+        assert len(results) == 1
+
+        results = discovery.find_by_protocol("mcp")
+        assert len(results) == 0
+
+    def test_remove(self, signed_card):
+        discovery = AICardDiscovery()
+        discovery.register(signed_card)
+        assert discovery.remove(signed_card.identity.did) is True
+        assert discovery.get(signed_card.identity.did) is None
+
+    def test_remove_nonexistent(self):
+        discovery = AICardDiscovery()
+        assert discovery.remove("did:mesh:nope") is False
+
+    def test_list_cards(self, identity, identity_b):
+        discovery = AICardDiscovery()
+        discovery.register(AICard.from_identity(identity))
+        discovery.register(AICard.from_identity(identity_b))
+        assert len(discovery.list_cards()) == 2
+
+    def test_is_verified_caching(self, signed_card):
+        discovery = AICardDiscovery()
+        discovery.register(signed_card)
+        assert discovery.is_verified(signed_card.identity.did) is True
+        # Second call uses cache
+        assert discovery.is_verified(signed_card.identity.did) is True
+
+    def test_is_verified_unknown_did(self):
+        discovery = AICardDiscovery()
+        assert discovery.is_verified("did:mesh:unknown") is False
+
+    def test_clear_cache(self, signed_card):
+        discovery = AICardDiscovery()
+        discovery.register(signed_card)
+        discovery.is_verified(signed_card.identity.did)
+        discovery.clear_cache()
+        # Still works after cache clear (re-verifies)
+        assert discovery.is_verified(signed_card.identity.did) is True


### PR DESCRIPTION
## Summary

Adds an AI Card adapter to AgentMesh, implementing the [AI Card](https://github.com/agent-card/ai-card) standard as the cross-protocol identity layer for agents.

This is the first implementation step in the pivot from embedding CMVK identity directly in A2A Agent Cards to using the AI Card standard for cross-protocol identity (see #146).

## What's New

### `src/agentmesh/integrations/ai_card/`

- **`schema.py`** — AI Card data models:
  - `AICard` — Main card with metadata, identity, verifiable data, services, signing
  - `AICardIdentity` — DID + Ed25519 public key
  - `AICardVerifiable` — Trust scores, capability attestations, delegation chains
  - `AICardService` — Protocol-specific entries (A2A, MCP, etc.)
  - `from_identity()` — Create signed card from `AgentIdentity`
  - `from_trusted_agent_card()` — Bridge from existing `TrustedAgentCard`
  - `to_json()` / `from_json()` — Serialize for `/.well-known/ai-card.json`

- **`discovery.py`** — `AICardDiscovery` catalog:
  - Register/lookup cards by DID
  - Find by capability or protocol
  - TTL-based verification caching
  - Catalog JSON for discovery endpoints

### Tests — 43 tests covering:
- Schema model creation
- Identity mapping from `AgentIdentity`
- Card signing and tamper detection
- JSON round-trip serialization
- `TrustedAgentCard` bridge
- Discovery catalog operations

## References

- Closes #147
- Closes #148
- Parent epic: #146
- AI Card spec: https://github.com/agent-card/ai-card
- AI Card proposal: https://github.com/Agent-Card/ai-card/issues/16
- A2A pivot context: https://github.com/a2aproject/A2A/pull/1455#issuecomment-3910608809
